### PR TITLE
[Draft] Configure SystemHealth::observe to use specified data dir 

### DIFF
--- a/beacon_node/http_api/src/lib.rs
+++ b/beacon_node/http_api/src/lib.rs
@@ -4078,9 +4078,10 @@ pub fn serve<T: BeaconChainTypes>(
         .and(warp::path("health"))
         .and(warp::path::end())
         .and(task_spawner_filter.clone())
-        .then(|task_spawner: TaskSpawner<T::EthSpec>| {
+        .and(data_dir_filter)
+        .then(|task_spawner: TaskSpawner<T::EthSpec>, data_dir| {
             task_spawner.blocking_json_task(Priority::P0, move || {
-                eth2::lighthouse::Health::observe()
+                eth2::lighthouse::Health::observe(data_dir)
                     .map(api_types::GenericResponse::from)
                     .map_err(warp_utils::reject::custom_bad_request)
             })

--- a/common/health_metrics/src/observe.rs
+++ b/common/health_metrics/src/observe.rs
@@ -8,10 +8,6 @@ use {
 };
 
 pub trait Observe: Sized {
-    #[cfg(not(target_os = "linux"))]
-    fn observe(_data_dir: PathBuf) -> Result<Self, String>;
-
-    #[cfg(target_os = "linux")]
     fn observe(data_dir: PathBuf) -> Result<Self, String>;
 }
 
@@ -37,7 +33,7 @@ impl Observe for SystemHealth {
     }
 
     #[cfg(target_os = "linux")]
-    fn observe(_data_dir: PathBuf) -> Result<Self, String> {
+    fn observe(data_dir: PathBuf) -> Result<Self, String> {
         let vm = psutil::memory::virtual_memory()
             .map_err(|e| format!("Unable to get virtual memory: {:?}", e))?;
         let loadavg =

--- a/common/health_metrics/src/observe.rs
+++ b/common/health_metrics/src/observe.rs
@@ -8,19 +8,19 @@ use {
 };
 
 pub trait Observe: Sized {
-    fn observe(data_dir: PathBuf) -> Result<Self, String>;
+    fn observe(data_dir: Option<PathBuf>) -> Result<Self, String>;
 }
 
 impl Observe for Health {
     #[cfg(not(target_os = "linux"))]
-    fn observe(_data_dir: PathBuf) -> Result<Self, String> {
+    fn observe() -> Result<Self, String> {
         Err("Health is only available on Linux".into())
     }
 
     #[cfg(target_os = "linux")]
     fn observe(data_dir: PathBuf) -> Result<Self, String> {
         Ok(Self {
-            process: ProcessHealth::observe()?,
+            process: ProcessHealth::observe(data_dir)?,
             system: SystemHealth::observe(data_dir)?,
         })
     }
@@ -28,7 +28,7 @@ impl Observe for Health {
 
 impl Observe for SystemHealth {
     #[cfg(not(target_os = "linux"))]
-    fn observe(_data_dir: PathBuf) -> Result<Self, String> {
+    fn observe() -> Result<Self, String> {
         Err("Health is only available on Linux".into())
     }
 

--- a/common/health_metrics/src/observe.rs
+++ b/common/health_metrics/src/observe.rs
@@ -1,4 +1,5 @@
 use eth2::lighthouse::{Health, ProcessHealth, SystemHealth};
+use std::path::PathBuf;
 
 #[cfg(target_os = "linux")]
 use {
@@ -7,32 +8,36 @@ use {
 };
 
 pub trait Observe: Sized {
-    fn observe() -> Result<Self, String>;
+    #[cfg(not(target_os = "linux"))]
+    fn observe(_data_dir: PathBuf) -> Result<Self, String>;
+
+    #[cfg(target_os = "linux")]
+    fn observe(data_dir: PathBuf) -> Result<Self, String>;
 }
 
 impl Observe for Health {
     #[cfg(not(target_os = "linux"))]
-    fn observe() -> Result<Self, String> {
+    fn observe(_data_dir: PathBuf) -> Result<Self, String> {
         Err("Health is only available on Linux".into())
     }
 
     #[cfg(target_os = "linux")]
-    fn observe() -> Result<Self, String> {
+    fn observe(data_dir: PathBuf) -> Result<Self, String> {
         Ok(Self {
             process: ProcessHealth::observe()?,
-            system: SystemHealth::observe()?,
+            system: SystemHealth::observe(data_dir)?,
         })
     }
 }
 
 impl Observe for SystemHealth {
     #[cfg(not(target_os = "linux"))]
-    fn observe() -> Result<Self, String> {
+    fn observe(_data_dir: PathBuf) -> Result<Self, String> {
         Err("Health is only available on Linux".into())
     }
 
     #[cfg(target_os = "linux")]
-    fn observe() -> Result<Self, String> {
+    fn observe(_data_dir: PathBuf) -> Result<Self, String> {
         let vm = psutil::memory::virtual_memory()
             .map_err(|e| format!("Unable to get virtual memory: {:?}", e))?;
         let loadavg =
@@ -41,8 +46,8 @@ impl Observe for SystemHealth {
         let cpu =
             psutil::cpu::cpu_times().map_err(|e| format!("Unable to get cpu times: {:?}", e))?;
 
-        let disk_usage = psutil::disk::disk_usage("/")
-            .map_err(|e| format!("Unable to disk usage info: {:?}", e))?;
+        let disk_usage = psutil::disk::disk_usage(&data_dir)
+            .map_err(|e| format!("Unable to disk usage info for {:?}: {:?}", data_dir, e))?;
 
         let disk = psutil::disk::DiskIoCountersCollector::default()
             .disk_io_counters()

--- a/common/health_metrics/src/observe.rs
+++ b/common/health_metrics/src/observe.rs
@@ -18,9 +18,9 @@ impl Observe for Health {
     }
 
     #[cfg(target_os = "linux")]
-    fn observe(data_dir: PathBuf) -> Result<Self, String> {
+    fn observe(data_dir: Option<PathBuf>) -> Result<Self, String> {
         Ok(Self {
-            process: ProcessHealth::observe(data_dir)?,
+            process: ProcessHealth::observe()?,
             system: SystemHealth::observe(data_dir)?,
         })
     }
@@ -33,7 +33,7 @@ impl Observe for SystemHealth {
     }
 
     #[cfg(target_os = "linux")]
-    fn observe(data_dir: PathBuf) -> Result<Self, String> {
+    fn observe(data_dir: Option<PathBuf>) -> Result<Self, String> {
         let vm = psutil::memory::virtual_memory()
             .map_err(|e| format!("Unable to get virtual memory: {:?}", e))?;
         let loadavg =
@@ -42,8 +42,18 @@ impl Observe for SystemHealth {
         let cpu =
             psutil::cpu::cpu_times().map_err(|e| format!("Unable to get cpu times: {:?}", e))?;
 
-        let disk_usage = psutil::disk::disk_usage(&data_dir)
-            .map_err(|e| format!("Unable to disk usage info for {:?}: {:?}", data_dir, e))?;
+        let disk_usage = if let Some(data_dir) = &data_dir {
+            psutil::disk::disk_usage(data_dir)
+                .map_err(|e| format!("Unable to disk usage info for {:?}: {:?}", data_dir, e))?
+        } else {
+            // Use root directory if no data_dir is provided
+            psutil::disk::disk_usage("/").map_err(|e| {
+                format!(
+                    "Unable to disk usage info for root ('/') directory: {:?}",
+                    e
+                )
+            })?
+        };
 
         let disk = psutil::disk::DiskIoCountersCollector::default()
             .disk_io_counters()

--- a/common/monitoring_api/src/gather.rs
+++ b/common/monitoring_api/src/gather.rs
@@ -190,7 +190,7 @@ pub fn gather_beacon_metrics(
 
     let beacon_metrics = gather_metrics(&BEACON_METRICS_MAP)
         .ok_or_else(|| "Failed to gather beacon metrics".to_string())?;
-    let process = eth2::lighthouse::ProcessHealth::observe()?.into();
+    let process = eth2::lighthouse::ProcessHealth::observe(db_path)?.into();
 
     Ok(BeaconProcessMetrics {
         beacon: beacon_metrics,
@@ -203,7 +203,7 @@ pub fn gather_validator_metrics() -> Result<ValidatorProcessMetrics, String> {
     let validator_metrics = gather_metrics(&VALIDATOR_METRICS_MAP)
         .ok_or_else(|| "Failed to gather validator metrics".to_string())?;
 
-    let process = eth2::lighthouse::ProcessHealth::observe()?.into();
+    let process = eth2::lighthouse::ProcessHealth::observe(db_path)?.into();
     Ok(ValidatorProcessMetrics {
         validator: validator_metrics,
         common: process,

--- a/common/monitoring_api/src/lib.rs
+++ b/common/monitoring_api/src/lib.rs
@@ -162,7 +162,15 @@ impl MonitoringHttpClient {
 
     /// Gets system metrics by observing capturing the SystemHealth metrics.
     pub fn get_system_metrics(&self) -> Result<MonitoringMetrics, Error> {
-        let system_health = SystemHealth::observe().map_err(Error::SystemMetricsFailed)?;
+        // For system metrics, use db_path if available, otherwise default to root
+        // directory ("/") for monitoring disk usage
+        let db_path = self
+            .db_path
+            .as_ref()
+            .map(|p| p.as_path())
+            .unwrap_or(Path::new("/"));
+
+        let system_health = SystemHealth::observe(db_path).map_err(Error::SystemMetricsFailed)?;
         Ok(MonitoringMetrics {
             metadata: Metadata::new(ProcessType::System),
             process_metrics: Process::System(system_health.into()),

--- a/validator_client/http_api/src/lib.rs
+++ b/validator_client/http_api/src/lib.rs
@@ -300,9 +300,10 @@ pub fn serve<T: 'static + SlotClock + Clone, E: EthSpec>(
     let get_lighthouse_health = warp::path("lighthouse")
         .and(warp::path("health"))
         .and(warp::path::end())
-        .then(|| {
+        .and(validator_dir_filter.clone())
+        .then(|validator_dir| {
             blocking_json_task(move || {
-                eth2::lighthouse::Health::observe()
+                eth2::lighthouse::Health::observe(validator_dir)
                     .map(api_types::GenericResponse::from)
                     .map_err(warp_utils::reject::custom_bad_request)
             })


### PR DESCRIPTION
Draft:
- Already cover necessary changes required to solve the issues
- Waiting for manual testing (especially Remote Monitoring via Beaconchain apps)
- Change observe() data_dir args as Option<PathBuf>

## Issue Addressed

Which issue # does this PR address?

## Proposed Changes

Please list or describe the changes introduced by this PR.

## Additional Info

Please provide any additional information. For example, future considerations
or information useful for reviewers.
